### PR TITLE
Add three known properties.

### DIFF
--- a/Source/StrongGrid/Utilities/WebHookEventConverter.cs
+++ b/Source/StrongGrid/Utilities/WebHookEventConverter.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using StrongGrid.Model.Webhooks;
 using System;
@@ -37,8 +37,10 @@ namespace StrongGrid.Utilities
 			"url",
 			"url_offset",
 			"useragent",
-			"userid",
-			"pool"
+			"sg_user_id",
+			"pool",
+			"marketing_campaign_id",
+			"marketing_campaign_name"
 		};
 
 		/// <summary>

--- a/Source/StrongGrid/Utilities/WebHookEventConverter.cs
+++ b/Source/StrongGrid/Utilities/WebHookEventConverter.cs
@@ -40,7 +40,9 @@ namespace StrongGrid.Utilities
 			"sg_user_id",
 			"pool",
 			"marketing_campaign_id",
-			"marketing_campaign_name"
+			"marketing_campaign_name",
+			"marketing_campaign_version",
+			"marketing_campaign_split_id"
 		};
 
 		/// <summary>


### PR DESCRIPTION
In my tests I found three SendGrid properties that are going to "unique arguments": 
"userid" change to "sg_user_id",
"marketing_campaign_id"
"marketing_campaign_name"

Also need to create property "userid" in the event class, because it comes in all events.