### PR TITLE
Fixed invalid cast exception when parsing floating point timestamps.

### DIFF
--- a/Source/StrongGrid/Utilities/EpochConverter.cs
+++ b/Source/StrongGrid/Utilities/EpochConverter.cs
@@ -51,7 +51,7 @@ namespace StrongGrid.Utilities
 		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
 		{
 			if (reader.Value == null) return null;
-			return _epoch.AddSeconds((long)reader.Value);
+			return _epoch.AddSeconds(Convert.ToDouble(reader.Value));
 		}
 	}
 }


### PR DESCRIPTION
The JSON sent by the SendGrid webhook (v3) will contain a `send_at` timestamp in a `processed` event. This timestamp is a floating point number. E.g., something like this:

```JSON
[
    {
        "email": "foo@bar.com",
        "smtp-id": "<WFQ7ZHXWSxKmS0NHhwM1Tg@ismtpd0002p1lon1.sendgrid.net>",
        "timestamp": 1487700673,
        "sg_event_id": "7oGeTSl-T3-DE6ICxFUAZA",
        "sg_message_id": "WFQ7XHXWSlKmS0NHhwM1Tg.filter0490p1las1-9298-58AC827A-13.0",
        "send_at": 1487700692.41447,
        "event": "processed"
    }
]
```

Calling `WebhookParser.ParseWebhookEvents` will fail with

> Specified cast is not valid.
>
>    at StrongGrid.Utilities.EpochConverter.ReadJson(JsonReader reader, Type objectType, Object existingValue, JsonSerializer serializer) in C:\projects\stronggrid\Source\StrongGrid\Utilities\EpochConverter.cs:line 54

I have fixed this problem by calling `Convert.ToDouble` on the JSON value. This correctly handles both the integer and the floating point case. Also, there is no extra conversion taking place as `DateTime.AddSeconds` expect a double argument.