### PR TITLE
Add Segment.RecipientCount

### DIFF
--- a/Source/StrongGrid/Model/Segment.cs
+++ b/Source/StrongGrid/Model/Segment.cs
@@ -42,5 +42,14 @@ namespace StrongGrid.Model
 		/// </value>
 		[JsonProperty("conditions", NullValueHandling = NullValueHandling.Ignore)]
 		public SearchCondition[] Conditions { get; set; }
+
+		/// <summary>
+		/// Gets or sets the recipient count.
+		/// </summary>
+		/// <value>
+		/// The recipient count.
+		/// </value>
+		[JsonProperty("recipient_count", NullValueHandling = NullValueHandling.Ignore)]
+		public long RecipientCount { get; set; }
 	}
 }

--- a/Source/StrongGrid/Resources/Segments.cs
+++ b/Source/StrongGrid/Resources/Segments.cs
@@ -142,7 +142,7 @@ namespace StrongGrid.Resources
 		/// <returns>
 		/// An array of <see cref="Contact" />.
 		/// </returns>
-		public Task<Contact[]> GetRecipientsAsync(long segmentId, int? recordsPerPage = null, int? page = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<Contact[]> GetRecipientsAsync(long segmentId, int recordsPerPage = 100, int page = 1, CancellationToken cancellationToken = default(CancellationToken))
 		{
 			return _client
 				.GetAsync($"{_endpoint}/{segmentId}/recipients")

--- a/Source/StrongGrid/Resources/Segments.cs
+++ b/Source/StrongGrid/Resources/Segments.cs
@@ -142,7 +142,7 @@ namespace StrongGrid.Resources
 		/// <returns>
 		/// An array of <see cref="Contact" />.
 		/// </returns>
-		public Task<Contact[]> GetRecipientsAsync(long segmentId, int recordsPerPage = 100, int page = 1, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<Contact[]> GetRecipientsAsync(long segmentId, int? recordsPerPage = null, int? page = null, CancellationToken cancellationToken = default(CancellationToken))
 		{
 			return _client
 				.GetAsync($"{_endpoint}/{segmentId}/recipients")


### PR DESCRIPTION
Hi,
I had some issues with querying segment recipients. "recipient_count" was not available, so total pages could not be calculated (API throws when querying non-existent page). So added Segment.RecipientCount.
Paging paramaters are optional according to the v3 spec., so changed recordsPerPage and page parameters to nullable and propose null for default values.