### PR TITLE
Fix for SendGrid Batches API 

### DIFF
--- a/Source/StrongGrid.IntegrationTests/Program.cs
+++ b/Source/StrongGrid.IntegrationTests/Program.cs
@@ -821,12 +821,19 @@ namespace StrongGrid.IntegrationTests
 			var isValid = await client.Batches.ValidateBatchIdAsync(batchId, cancellationToken).ConfigureAwait(false);
 			await log.WriteLineAsync($"{batchId} is valid: {isValid}").ConfigureAwait(false);
 
+			var batchStatus = await client.Batches.GetAsync( batchId, cancellationToken ).ConfigureAwait( false );
+			var firstBatchStatus = batchStatus?.FirstOrDefault();
+			await log.WriteLineAsync( $"There are {batchStatus?.Length} batches. " + (firstBatchStatus != null ? $" {firstBatchStatus.BatchId} found, status is {firstBatchStatus.Status}" : "") ).ConfigureAwait( false );
+
 			batchId = "some_bogus_batch_id";
 			isValid = await client.Batches.ValidateBatchIdAsync(batchId, cancellationToken).ConfigureAwait(false);
 			await log.WriteLineAsync($"{batchId} is valid: {isValid}").ConfigureAwait(false);
 
 			var batches = await client.Batches.GetAllAsync(cancellationToken).ConfigureAwait(false);
 			await log.WriteLineAsync($"All batches retrieved. There are {batches.Length} batches").ConfigureAwait(false);
+
+			batchStatus = await client.Batches.GetAsync( batchId, cancellationToken ).ConfigureAwait( false );
+			await log.WriteLineAsync( $"{batchId} " + (batchStatus == null || batchStatus.Length == 0 ?  "does not exist" : "exists") ).ConfigureAwait( false );
 		}
 
 		private static async Task Whitelabel(IClient client, TextWriter log, CancellationToken cancellationToken)

--- a/Source/StrongGrid.IntegrationTests/Program.cs
+++ b/Source/StrongGrid.IntegrationTests/Program.cs
@@ -822,8 +822,7 @@ namespace StrongGrid.IntegrationTests
 			await log.WriteLineAsync($"{batchId} is valid: {isValid}").ConfigureAwait(false);
 
 			var batchStatus = await client.Batches.GetAsync( batchId, cancellationToken ).ConfigureAwait( false );
-			var firstBatchStatus = batchStatus?.FirstOrDefault();
-			await log.WriteLineAsync( $"There are {batchStatus?.Length} batches. " + (firstBatchStatus != null ? $" {firstBatchStatus.BatchId} found, status is {firstBatchStatus.Status}" : "") ).ConfigureAwait( false );
+			await log.WriteLineAsync( $"{batchId} " + (batchStatus == null ? "not found" : $"found, status is {batchStatus.Status}") ).ConfigureAwait( false );
 
 			batchId = "some_bogus_batch_id";
 			isValid = await client.Batches.ValidateBatchIdAsync(batchId, cancellationToken).ConfigureAwait(false);
@@ -833,7 +832,7 @@ namespace StrongGrid.IntegrationTests
 			await log.WriteLineAsync($"All batches retrieved. There are {batches.Length} batches").ConfigureAwait(false);
 
 			batchStatus = await client.Batches.GetAsync( batchId, cancellationToken ).ConfigureAwait( false );
-			await log.WriteLineAsync( $"{batchId} " + (batchStatus == null || batchStatus.Length == 0 ?  "does not exist" : "exists") ).ConfigureAwait( false );
+			await log.WriteLineAsync( $"{batchId} " + (batchStatus == null ? "does not exist" : "exists") ).ConfigureAwait( false );
 		}
 
 		private static async Task Whitelabel(IClient client, TextWriter log, CancellationToken cancellationToken)

--- a/Source/StrongGrid.UnitTests/Resources/BatchesTests.cs
+++ b/Source/StrongGrid.UnitTests/Resources/BatchesTests.cs
@@ -30,6 +30,14 @@ namespace StrongGrid.UnitTests.Resources
 				'status': 'pause'
 			}
 		]";
+		private const string MULTIPLE_BATCHES_SINGLE_ITEM_JSON = @"[
+			{
+				'batch_id': 'BATCH_ID_1',
+				'status': 'cancel'
+			}
+		]";
+		private const string EMPTY_BATCHES_JSON = @"[
+		]";
 
 		#endregion
 
@@ -197,6 +205,48 @@ namespace StrongGrid.UnitTests.Resources
 			mockHttp.VerifyNoOutstandingRequest();
 			result.ShouldNotBeNull();
 			result.Length.ShouldBe(2);
+		}
+
+		[Fact]
+		public async Task GetAsync()
+		{
+			// Arrange
+			var batchId = "YOUR_BATCH_ID";
+
+			var mockHttp = new MockHttpMessageHandler();
+			mockHttp.Expect( HttpMethod.Get, Utils.GetSendGridApiUri( "user/scheduled_sends" ) ).Respond( "application/json", MULTIPLE_BATCHES_SINGLE_ITEM_JSON );
+
+			var client = Utils.GetFluentClient( mockHttp );
+			var batches = new Batches( client );
+
+			// Act
+			var result = await batches.GetAsync(batchId).ConfigureAwait( false );
+
+			// Assert
+			mockHttp.VerifyNoOutstandingExpectation();
+			mockHttp.VerifyNoOutstandingRequest();
+			result.ShouldNotBeNull();
+		}
+
+		[Fact]
+		public async Task GetAsync_doesnt_exist()
+		{
+			// Arrange
+			var batchId = "YOUR_BATCH_ID";
+
+			var mockHttp = new MockHttpMessageHandler();
+			mockHttp.Expect( HttpMethod.Get, Utils.GetSendGridApiUri( "user/scheduled_sends" ) ).Respond( "application/json", EMPTY_BATCHES_JSON );
+
+			var client = Utils.GetFluentClient( mockHttp );
+			var batches = new Batches( client );
+
+			// Act
+			var result = await batches.GetAsync( batchId ).ConfigureAwait( false );
+
+			// Assert
+			mockHttp.VerifyNoOutstandingExpectation();
+			mockHttp.VerifyNoOutstandingRequest();
+			result.ShouldBeNull();
 		}
 
 		[Fact]

--- a/Source/StrongGrid.UnitTests/Resources/BatchesTests.cs
+++ b/Source/StrongGrid.UnitTests/Resources/BatchesTests.cs
@@ -214,7 +214,7 @@ namespace StrongGrid.UnitTests.Resources
 			var batchId = "YOUR_BATCH_ID";
 
 			var mockHttp = new MockHttpMessageHandler();
-			mockHttp.Expect( HttpMethod.Get, Utils.GetSendGridApiUri( "user/scheduled_sends" ) ).Respond( "application/json", MULTIPLE_BATCHES_SINGLE_ITEM_JSON );
+			mockHttp.Expect( HttpMethod.Get, Utils.GetSendGridApiUri( "user/scheduled_sends", batchId ) ).Respond( "application/json", MULTIPLE_BATCHES_SINGLE_ITEM_JSON );
 
 			var client = Utils.GetFluentClient( mockHttp );
 			var batches = new Batches( client );
@@ -226,6 +226,7 @@ namespace StrongGrid.UnitTests.Resources
 			mockHttp.VerifyNoOutstandingExpectation();
 			mockHttp.VerifyNoOutstandingRequest();
 			result.ShouldNotBeNull();
+			result.Length.ShouldBe(1);
 		}
 
 		[Fact]
@@ -235,7 +236,7 @@ namespace StrongGrid.UnitTests.Resources
 			var batchId = "YOUR_BATCH_ID";
 
 			var mockHttp = new MockHttpMessageHandler();
-			mockHttp.Expect( HttpMethod.Get, Utils.GetSendGridApiUri( "user/scheduled_sends" ) ).Respond( "application/json", EMPTY_BATCHES_JSON );
+			mockHttp.Expect( HttpMethod.Get, Utils.GetSendGridApiUri( "user/scheduled_sends", batchId ) ).Respond( "application/json", EMPTY_BATCHES_JSON );
 
 			var client = Utils.GetFluentClient( mockHttp );
 			var batches = new Batches( client );
@@ -246,7 +247,8 @@ namespace StrongGrid.UnitTests.Resources
 			// Assert
 			mockHttp.VerifyNoOutstandingExpectation();
 			mockHttp.VerifyNoOutstandingRequest();
-			result.ShouldBeNull();
+			result.ShouldNotBeNull();
+			result.Length.ShouldBe(0);
 		}
 
 		[Fact]

--- a/Source/StrongGrid.UnitTests/Resources/BatchesTests.cs
+++ b/Source/StrongGrid.UnitTests/Resources/BatchesTests.cs
@@ -226,7 +226,6 @@ namespace StrongGrid.UnitTests.Resources
 			mockHttp.VerifyNoOutstandingExpectation();
 			mockHttp.VerifyNoOutstandingRequest();
 			result.ShouldNotBeNull();
-			result.Length.ShouldBe(1);
 		}
 
 		[Fact]
@@ -247,8 +246,7 @@ namespace StrongGrid.UnitTests.Resources
 			// Assert
 			mockHttp.VerifyNoOutstandingExpectation();
 			mockHttp.VerifyNoOutstandingRequest();
-			result.ShouldNotBeNull();
-			result.Length.ShouldBe(0);
+			result.ShouldBeNull();
 		}
 
 		[Fact]

--- a/Source/StrongGrid/Resources/Batches.cs
+++ b/Source/StrongGrid/Resources/Batches.cs
@@ -3,6 +3,7 @@ using Pathoschild.Http.Client;
 using StrongGrid.Models;
 using StrongGrid.Utilities;
 using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -135,12 +136,15 @@ namespace StrongGrid.Resources
 		/// <returns>
 		/// A <see cref="BatchInfo" />.
 		/// </returns>
-		public Task<BatchInfo[]> GetAsync(string batchId, CancellationToken cancellationToken = default(CancellationToken))
+		public async Task<BatchInfo> GetAsync(string batchId, CancellationToken cancellationToken = default(CancellationToken))
 		{
-			return _client
+			var result = await _client
 				.GetAsync($"user/scheduled_sends/{batchId}")
 				.WithCancellationToken(cancellationToken)
-				.AsSendGridObject<BatchInfo[]>();
+				.AsSendGridObject<BatchInfo[]>()
+				.ConfigureAwait(false);
+
+			return result.FirstOrDefault();
 		}
 
 		/// <summary>

--- a/Source/StrongGrid/Resources/Batches.cs
+++ b/Source/StrongGrid/Resources/Batches.cs
@@ -135,12 +135,12 @@ namespace StrongGrid.Resources
 		/// <returns>
 		/// A <see cref="BatchInfo" />.
 		/// </returns>
-		public Task<BatchInfo> GetAsync(string batchId, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<BatchInfo[]> GetAsync(string batchId, CancellationToken cancellationToken = default(CancellationToken))
 		{
 			return _client
 				.GetAsync($"user/scheduled_sends/{batchId}")
 				.WithCancellationToken(cancellationToken)
-				.AsSendGridObject<BatchInfo>();
+				.AsSendGridObject<BatchInfo[]>();
 		}
 
 		/// <summary>

--- a/Source/StrongGrid/Resources/IBatches.cs
+++ b/Source/StrongGrid/Resources/IBatches.cs
@@ -66,7 +66,7 @@ namespace StrongGrid.Resources
 		/// <returns>
 		/// A <see cref="BatchInfo" />.
 		/// </returns>
-		Task<BatchInfo> GetAsync(string batchId, CancellationToken cancellationToken = default(CancellationToken));
+		Task<BatchInfo[]> GetAsync(string batchId, CancellationToken cancellationToken = default(CancellationToken));
 
 		/// <summary>
 		/// Delete the cancellation/pause of a scheduled send.

--- a/Source/StrongGrid/Resources/IBatches.cs
+++ b/Source/StrongGrid/Resources/IBatches.cs
@@ -66,7 +66,7 @@ namespace StrongGrid.Resources
 		/// <returns>
 		/// A <see cref="BatchInfo" />.
 		/// </returns>
-		Task<BatchInfo[]> GetAsync(string batchId, CancellationToken cancellationToken = default(CancellationToken));
+		Task<BatchInfo> GetAsync(string batchId, CancellationToken cancellationToken = default(CancellationToken));
 
 		/// <summary>
 		/// Delete the cancellation/pause of a scheduled send.


### PR DESCRIPTION
OK, this is stupid, but it looks like the SendGrid Batches API (https://sendgrid.com/docs/API_Reference/Web_API_v3/cancel_schedule_send.html) returns an array of results when you request the status of a single batch. StrongGrid (sensibly) expects it to be a single item.

This PR fixes the bug 