### PR TITLE
Add ability to remove recipients from list in batch

### DIFF
--- a/Source/StrongGrid.UnitTests/Resources/ListsTests.cs
+++ b/Source/StrongGrid.UnitTests/Resources/ListsTests.cs
@@ -275,5 +275,26 @@ namespace StrongGrid.UnitTests.Resources
 			mockHttp.VerifyNoOutstandingExpectation();
 			mockHttp.VerifyNoOutstandingRequest();
 		}
+
+		[Fact]
+		public async Task RemoveRecipientsAsync()
+		{
+			// Arrange
+			var listId = 1;
+			var contactIds = new[] { "abc123", "def456" };
+
+			var mockHttp = new MockHttpMessageHandler();
+			mockHttp.Expect(HttpMethod.Post, Utils.GetSendGridApiUri(ENDPOINT, listId, "recipients")).Respond(HttpStatusCode.NoContent);
+
+			var client = Utils.GetFluentClient(mockHttp);
+			var lists = new Lists(client);
+
+			// Act
+			await lists.RemoveRecipientsAsync(listId, contactIds, null, CancellationToken.None).ConfigureAwait(false);
+
+			// Assert
+			mockHttp.VerifyNoOutstandingExpectation();
+			mockHttp.VerifyNoOutstandingRequest();
+		}
 	}
 }

--- a/Source/StrongGrid.UnitTests/Resources/ListsTests.cs
+++ b/Source/StrongGrid.UnitTests/Resources/ListsTests.cs
@@ -284,7 +284,7 @@ namespace StrongGrid.UnitTests.Resources
 			var contactIds = new[] { "abc123", "def456" };
 
 			var mockHttp = new MockHttpMessageHandler();
-			mockHttp.Expect(HttpMethod.Post, Utils.GetSendGridApiUri(ENDPOINT, listId, "recipients")).Respond(HttpStatusCode.NoContent);
+			mockHttp.Expect(HttpMethod.Delete, Utils.GetSendGridApiUri(ENDPOINT, listId, "recipients")).Respond(HttpStatusCode.NoContent);
 
 			var client = Utils.GetFluentClient(mockHttp);
 			var lists = new Lists(client);

--- a/Source/StrongGrid/Resources/ILists.cs
+++ b/Source/StrongGrid/Resources/ILists.cs
@@ -127,5 +127,17 @@ namespace StrongGrid.Resources
 		/// The async task.
 		/// </returns>
 		Task AddRecipientsAsync(long listId, IEnumerable<string> contactIds, string onBehalfOf = null, CancellationToken cancellationToken = default(CancellationToken));
+
+		/// <summary>
+		/// Remove a recipient from a list.
+		/// </summary>
+		/// <param name="listId">The list identifier.</param>
+		/// <param name="contactIds">The contact identifier.</param>
+		/// <param name="onBehalfOf">The user to impersonate</param>
+		/// <param name="cancellationToken">The cancellation token.</param>
+		/// <returns>
+		/// The async task.
+		/// </returns>
+		Task RemoveRecipientsAsync(long listId, IEnumerable<string> contactIds, string onBehalfOf = null, CancellationToken cancellationToken = default(CancellationToken));
 	}
 }

--- a/Source/StrongGrid/Resources/ILists.cs
+++ b/Source/StrongGrid/Resources/ILists.cs
@@ -129,7 +129,7 @@ namespace StrongGrid.Resources
 		Task AddRecipientsAsync(long listId, IEnumerable<string> contactIds, string onBehalfOf = null, CancellationToken cancellationToken = default(CancellationToken));
 
 		/// <summary>
-		/// Remove a recipient from a list.
+		/// Remove multiple recipients from a list.
 		/// </summary>
 		/// <param name="listId">The list identifier.</param>
 		/// <param name="contactIds">The contact identifier.</param>

--- a/Source/StrongGrid/Resources/Lists.cs
+++ b/Source/StrongGrid/Resources/Lists.cs
@@ -238,5 +238,24 @@ namespace StrongGrid.Resources
 				.WithCancellationToken(cancellationToken)
 				.AsMessage();
 		}
+
+		/// <summary>
+		/// Remove a recipient from a list.
+		/// </summary>
+		/// <param name="listId">The list identifier.</param>
+		/// <param name="contactIds">The contact identifier.</param>
+		/// <param name="onBehalfOf">The user to impersonate</param>
+		/// <param name="cancellationToken">The cancellation token.</param>
+		/// <returns>
+		/// The async task.
+		/// </returns>
+		public Task RemoveRecipientsAsync(long listId, IEnumerable<string> contactIds, string onBehalfOf = null, CancellationToken cancellationToken = default(CancellationToken))
+		{
+			return _client
+				.DeleteAsync($"{_endpoint}/{listId}/recipients")
+				.OnBehalfOf(onBehalfOf)
+				.WithCancellationToken(cancellationToken)
+				.AsMessage();
+		}
 	}
 }

--- a/Source/StrongGrid/Resources/Lists.cs
+++ b/Source/StrongGrid/Resources/Lists.cs
@@ -240,7 +240,7 @@ namespace StrongGrid.Resources
 		}
 
 		/// <summary>
-		/// Remove a recipient from a list.
+		/// Remove multiple recipients from a list.
 		/// </summary>
 		/// <param name="listId">The list identifier.</param>
 		/// <param name="contactIds">The contact identifier.</param>
@@ -251,9 +251,11 @@ namespace StrongGrid.Resources
 		/// </returns>
 		public Task RemoveRecipientsAsync(long listId, IEnumerable<string> contactIds, string onBehalfOf = null, CancellationToken cancellationToken = default(CancellationToken))
 		{
+			var data = JArray.FromObject(contactIds.ToArray());
 			return _client
 				.DeleteAsync($"{_endpoint}/{listId}/recipients")
 				.OnBehalfOf(onBehalfOf)
+				.WithJsonBody(data)
 				.WithCancellationToken(cancellationToken)
 				.AsMessage();
 		}


### PR DESCRIPTION
This endpoint isn't documented in [SendGrid's official documentation](https://sendgrid.com/docs/API_Reference/Web_API_v3/Marketing_Campaigns/contactdb.html), but it does work. I'm hoping this can be added to StrongGrid even though it's _unofficial_. 