### PR TITLE
Changed resuts to results in Sender authentication

### DIFF
--- a/Source/StrongGrid.IntegrationTests/Program.cs
+++ b/Source/StrongGrid.IntegrationTests/Program.cs
@@ -1042,6 +1042,11 @@ namespace StrongGrid.IntegrationTests
 
 			await client.SenderAuthentication.DeleteDomainAsync(domain.Id, null, cancellationToken).ConfigureAwait(false);
 			await log.WriteLineAsync($"AuthenticatedSender domain {domain.Id} deleted.").ConfigureAwait(false);
+			await log.WriteLineAsync($"AuthenticatedSender domain validation: {domainValidation.IsValid}").ConfigureAwait(false);
+			await log.WriteLineAsync($"  Dkim1 validation: {domainValidation.ValidationResults.Dkim1.IsValid}").ConfigureAwait(false);
+			await log.WriteLineAsync($"  Dkim2 validation: {domainValidation.ValidationResults.Dkim2.IsValid}").ConfigureAwait(false);
+			await log.WriteLineAsync($"  Mail validation: {domainValidation.ValidationResults.Mail.IsValid}").ConfigureAwait(false);
+			await log.WriteLineAsync($"  SPF validation: {domainValidation.ValidationResults.Spf.IsValid}").ConfigureAwait(false);
 
 
 			await log.WriteLineAsync("\n***** SENDER AUTHENTICATION: Reverse DNS *****").ConfigureAwait(false);

--- a/Source/StrongGrid.UnitTests/Resources/SenderAuthenticationTests.cs
+++ b/Source/StrongGrid.UnitTests/Resources/SenderAuthenticationTests.cs
@@ -519,7 +519,7 @@ namespace StrongGrid.UnitTests.Resources
 			var apiResponse = @"{
 				'id': 1,
 				'valid': true,
-				'validation_resuts': {
+				'validation_results': {
 					'mail_cname': {
 						'valid': false,
 						'reason': 'Expected your MX record to be \'mx.sendgrid.net\' but found \'example.com\'.'

--- a/Source/StrongGrid/Models/DomainValidation.cs
+++ b/Source/StrongGrid/Models/DomainValidation.cs
@@ -31,7 +31,7 @@ namespace StrongGrid.Models
 		/// <value>
 		/// The validation results.
 		/// </value>
-		[JsonProperty("validation_resuts", NullValueHandling = NullValueHandling.Ignore)]
+		[JsonProperty("validation_results", NullValueHandling = NullValueHandling.Ignore)]
 		public DomainValidationResults ValidationResults { get; set; }
 	}
 }


### PR DESCRIPTION
There was a misspelled JSON property in the Sender Authentication for Domain Validation.

This likely has come from this issue:
https://github.com/sendgrid/sendgrid-oai/issues/67