### PR TITLE
Added typed exception to the error handler

### DIFF
--- a/Source/StrongGrid/Utilities/SendGridErrorHandler.cs
+++ b/Source/StrongGrid/Utilities/SendGridErrorHandler.cs
@@ -1,7 +1,6 @@
 ﻿using Newtonsoft.Json.Linq;
 using Pathoschild.Http.Client;
 using Pathoschild.Http.Client.Extensibility;
-using System;
 using System.Net.Http;
 using System.Threading.Tasks;
 
@@ -27,7 +26,7 @@ namespace StrongGrid.Utilities
 			if (response.Message.IsSuccessStatusCode) return;
 
 			var errorMessage = GetErrorMessage(response.Message).Result;
-			throw new Exception(errorMessage);
+			throw new SendGridException(errorMessage, response.Message.StatusCode);
 		}
 
 		private static async Task<string> GetErrorMessage(HttpResponseMessage message)

--- a/Source/StrongGrid/Utilities/SendGridException.cs
+++ b/Source/StrongGrid/Utilities/SendGridException.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Net;
+
+namespace StrongGrid.Utilities
+{
+	/// <summary>
+	/// Exception that includes both the formatted message and the status code.
+	/// </summary>
+	public class SendGridException : Exception
+	{
+		/// <summary>
+		/// The status code of the non-successful call
+		/// </summary>
+		public HttpStatusCode StatusCode { get; }
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="SendGridException"/> class.
+		/// </summary>
+		/// <param name="message">The exception message</param>
+		/// <param name="statusCode">The status code of the non-successful call</param>
+		public SendGridException(string message, HttpStatusCode statusCode)
+			: base(message)
+		{
+			StatusCode = statusCode;
+		}
+	}
+}


### PR DESCRIPTION
Basically wanted a way of exposing the status code when an Exception happens.

This allows the consumer to decide whether they want to retry the request or not (e.g. a conflict we probably don't want to retry but an intermittent 500 we might want to)