### PR TITLE
Fix "NullReference exception if pass BCC without TO to SendAsync"

### DIFF
--- a/Source/StrongGrid.UnitTests/Resources/MailTests.cs
+++ b/Source/StrongGrid.UnitTests/Resources/MailTests.cs
@@ -81,6 +81,38 @@ namespace StrongGrid.UnitTests.Resources
 		}
 
 		[Fact]
+		public async Task SendAsync_request_with_bcc_only()
+		{
+			// Arrange
+			var mockHttp = new MockHttpMessageHandler();
+			mockHttp.Expect(HttpMethod.Post, Utils.GetSendGridApiUri(ENDPOINT, "send")).Respond((HttpRequestMessage request) =>
+			{
+				var response = new HttpResponseMessage(HttpStatusCode.OK);
+				response.Headers.Add("X-Message-Id", "abc123");
+				return response;
+			});
+
+			var client = Utils.GetFluentClient(mockHttp);
+			var mail = new Mail(client);
+
+			var personalizations = new[]
+			{
+				new MailPersonalization()
+				{
+					Bcc = new[] { new MailAddress("bob@example.com", "Bob Smith"), new MailAddress("bob@example.com", "Bob Smith") }
+				}
+			};
+
+			// Act
+			var result = await mail.SendAsync(personalizations, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, CancellationToken.None).ConfigureAwait(false);
+
+			// Assert
+			mockHttp.VerifyNoOutstandingExpectation();
+			mockHttp.VerifyNoOutstandingRequest();
+			result.ShouldBe("abc123");
+		}
+
+		[Fact]
 		public async Task SendToSingleRecipientAsync()
 		{
 			// Arrange

--- a/Source/StrongGrid/Resources/Mail.cs
+++ b/Source/StrongGrid/Resources/Mail.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Pathoschild.Http.Client;
 using StrongGrid.Models;
@@ -526,12 +526,12 @@ namespace StrongGrid.Resources
 					.ToArray();
 				personalization.Cc = personalization.Cc?
 					.Distinct(emailAddressComparer)
-					.Except(personalization.To, emailAddressComparer)
+					.Except(personalization.To ?? new MailAddress[] { }, emailAddressComparer)
 					.ToArray();
 				personalization.Bcc = personalization.Bcc?
 					.Distinct(emailAddressComparer)
-					.Except(personalization.To, emailAddressComparer)
-					.Except(personalization.Cc, emailAddressComparer)
+					.Except(personalization.To ?? new MailAddress[] { }, emailAddressComparer)
+					.Except(personalization.Cc ?? new MailAddress[] { }, emailAddressComparer)
 					.ToArray();
 
 				// SendGrid doesn't like empty arrays


### PR DESCRIPTION
Here is fix for https://github.com/Jericho/StrongGrid/issues/286

It contains the fix itself and the test.