### PR TITLE
Update min supported Framework version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ using StrongGrid;
 
 ## .NET framework suport
 
-StrongGrid supports the `4.5.2` .NET framework as well as `.Net Core`.
+StrongGrid supports the `4.6.1` .NET framework as well as `.NET Core`.
 
 
 ## Usage


### PR DESCRIPTION
1. I had been using version 0.50.2 (which upgraded just fine via NuGet from 0.30.x), but upgrading to 0.60.0 gave me an error saying that it didn't contain anything that would work with 4.5.2, and I didn't see any notes / issues relating to this library changing its Framework version. I just figured I would try changing my projects target version to see what happens and it worked. Hopefully this will reduce confusion for others.

2. Minor cosmetic update from ".Net" to be ".NET" as that is the official casing, as shown here (and many other places): 

    https://docs.microsoft.com/en-us/dotnet/core/
